### PR TITLE
Updating section of CleanUp() method that sets test status

### DIFF
--- a/SaucePNUnit_Test.cs
+++ b/SaucePNUnit_Test.cs
@@ -58,7 +58,7 @@ namespace Saucey_Selenium {
         [TearDown]
         public void CleanUp()
         {
-            bool passed = TestContext.CurrentContext.Result.Status == TestStatus.Passed;
+            bool passed = TestContext.CurrentContext.Result.Outcome.Status == NUnit.Framework.Interfaces.TestStatus.Passed;
             try
             {
                 // Logs the result to Sauce Labs


### PR DESCRIPTION
Old way of changing the status was using NUnit 2.64 methodology. This new way incorporates the way to change the status when using NUnit3